### PR TITLE
Add support for AWSCLI profile and region

### DIFF
--- a/bin/ec2
+++ b/bin/ec2
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import sys
 import argparse
@@ -85,6 +85,12 @@ if __name__ == "__main__":
     parser.add_argument('--secret-key', dest='secret_key',
                     help='AWS Secret Key', metavar='AWS_SECRET_KEY')
 
+    parser.add_argument('--region', dest='region',
+                    help='AWS default region', metavar='AWS_REGION')
+
+    parser.add_argument('--profile', dest='profile', default='default',
+                    help='AWSCLI profile', metavar='AWS_PROFILE')
+
     # sub-commands
     subparsers = parser.add_subparsers()
 
@@ -126,13 +132,24 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config = ConfigParser.ConfigParser()
-    config.read(args.config)
+    if not args.region:
+        try:
+            config = ConfigParser.ConfigParser()
+            config.read(expanduser("~/.aws/config"))
+
+            profile = args.profile or 'default'
+            args.region = config.get('profile ' + profile, 'region')
+        except:
+            args.region = 'us-east-1'
 
     try:
         if not args.secret_key and not args.access_key:
-            args.access_key = config.get('default', 'aws_access_key_id')
-            args.secret_key = config.get('default', 'aws_secret_access_key')
+            credentials = ConfigParser.ConfigParser()
+            credentials.read(args.config)
+
+            args.access_key = credentials.get(args.profile, 'aws_access_key_id')
+            args.secret_key = credentials.get(args.profile, 'aws_secret_access_key')
+
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
         sys.stderr.write("ERROR: Malformed config file: {config}\n".format(
             config=args.config

--- a/heisenberg/__init__.py
+++ b/heisenberg/__init__.py
@@ -18,6 +18,7 @@ class Heisenberg(object):
         self.boto_conn = BotoEC2Helper(
             access_key=args.access_key,
             secret_key=args.secret_key,
+            region=args.region,
             cache_file=args.cache_file,
         )
 

--- a/heisenberg/utils.py
+++ b/heisenberg/utils.py
@@ -1,4 +1,4 @@
-import boto
+import boto.ec2
 import json
 
 
@@ -16,9 +16,10 @@ class BotoEC2Helper(object):
         'instance-state-name': 'running'
     }
 
-    def __init__(self, access_key, secret_key, cache_file):
+    def __init__(self, access_key, secret_key, region, cache_file):
         self.access_key = access_key
         self.secret_key = secret_key
+        self.region = region
         self.cache_file = cache_file
 
         try:
@@ -27,7 +28,8 @@ class BotoEC2Helper(object):
             self.cache = None
 
     def connect(self):
-        self.conn = boto.connect_ec2(
+        self.conn = boto.ec2.connect_to_region(
+            self.region,
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
         )


### PR DESCRIPTION
Add a flag to explicitly specify the region.
Use the ~/.aws/config to determine region based on the profile if
provided.